### PR TITLE
Forced the use of chalk v4 because version >= 5 switched to ESM ("Error [ERR_REQUIRE_ESM]: require() of ES Module")

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		""
 	],
 	"dependencies": {
-		"chalk": "*",
+		"chalk": "^4",
 		"heredoc": "^1.3.1"
 	}
 }


### PR DESCRIPTION
Today by default, the Chalk version >= 5 is used, you must specify version 4 to avoid the exception: "Error [ERR_REQUIRE_ESM]: require() of ES Module"